### PR TITLE
zlib now compiles using vita toolchain

### DIFF
--- a/install_on_linux.sh
+++ b/install_on_linux.sh
@@ -439,6 +439,12 @@ install_zlib_vitasdk() {
     tar -xf "zlib-${ZLIB_VERSION}.tar.gz"
     cd "zlib-${ZLIB_VERSION}" || return 1
 
+    # Use vita tools for compilation
+    export CC=arm-vita-eabi-gcc
+    export AR=arm-vita-eabi-ar
+    export RANLIB=arm-vita-eabi-ranlib
+    export STRIP=arm-vita-eabi-strip
+
     # Build and install zlib for VitaSDK
     echo "Building and installing zlib for VitaSDK..."
     ./configure --prefix="$VITASDK_PREFIX"


### PR DESCRIPTION
Solves #1.

After manually exporting the names for the vita tools, the compilation completes of Baba is You.

```
Compiling project...
[  4%] Building C object CMakeFiles/so_loader.dir/loader/default_dynlib.c.obj
[  9%] Building C object CMakeFiles/so_loader.dir/loader/patch_game.c.obj
[ 13%] Linking C executable so_loader
Building stubs for libc_bridge
[ 81%] Built target so_loader
[ 86%] Converting to Sony ELF so_loader.velf
[ 86%] Built target so_loader-velf
[ 90%] Creating SELF eboot.bin
[ 90%] Built target eboot.bin-self
[ 95%] Generating param.sfo for BABAISYOU.vpk
[100%] Building vpk BABAISYOU.vpk
[100%] Built target BABAISYOU.vpk-vpk
Android port compiled successfully! VPK generated: /usr/local/vitasdk//baba-is-you-vita/build/BABAISYOU.vpk
```

If there is a better solution, one can do that, but I just did this to quickly move on with porting progress.
